### PR TITLE
Feature: Supports multi match.

### DIFF
--- a/src/main/kotlin/xyz/salieri/english/type/Comp.kt
+++ b/src/main/kotlin/xyz/salieri/english/type/Comp.kt
@@ -117,7 +117,7 @@ class Comp(number: Long){
                 objEvent = listenFor(5000, obj.word)
                 if(objEvent == null){
                     // 第二个提示，当单词长度大于3才给，给出第二个字母
-                    if (obj.word.length > 3){
+                    if (obj.word.split('/')[0].length > 3){
                         msg += "10s内没人猜出来啦，再给你们个提示\n"
                         msg += "这个单词的前三个字母是${obj.word[0]}${obj.word[1]}${obj.word[2]}"
                         this.sendMsg()

--- a/src/main/kotlin/xyz/salieri/english/type/Comp.kt
+++ b/src/main/kotlin/xyz/salieri/english/type/Comp.kt
@@ -100,9 +100,11 @@ class Comp(number: Long){
             this.msg = wordToQuestion(this.quesindex,this.quesnum,obj,this.timelim)
             this.sendMsg()
             // 建立【带超时的监听】，分别是5s（提示第一个字母），5s（提示前三个字母），10s
-            suspend fun listenFor(timeoutMillis: Long, expect: String): GroupMessageEvent? {
+            suspend fun listenFor(timeoutMillis: Long, expects: String): GroupMessageEvent? {
                 return nextEventOrNull<GroupMessageEvent>(timeoutMillis) {
-                    it.message.contentToString().trim().equals(expect, ignoreCase = true)
+                    expects.split("/").any {expect ->
+                        it.message.contentToString().trim().equals(expect, ignoreCase = true)
+                    }
                 }
             }
             var objEvent: GroupMessageEvent? = listenFor(5000L, obj.word)

--- a/src/main/kotlin/xyz/salieri/mirai/plugin/EnglishTools.kt
+++ b/src/main/kotlin/xyz/salieri/mirai/plugin/EnglishTools.kt
@@ -38,6 +38,6 @@ fun wordToQuestion(index: Int,total: Int,word: Word,timeLim: Long): String{
         ${word.trans.joinToString("\n") {
             "#[${it.pos}] ${it.tran}"
         }}
-        #这个单词有${word.word.length}个字母
+        #这个单词有${word.word.split('/')[0].length}个字母
         """.trimMargin("#")
 }


### PR DESCRIPTION
Now supports matching words with format `A/B/C`, which means that the user's input matches any of the candidates, his answer will be considered correct.
This could be used for words like `analyze`/`analyse` and Japanese words (allow users to type kanas or kanji.)

支持多匹配机制。如果单词格式为`A/B/C`，则用户输入只要匹配其中任意一个，其回答就会被认为是正确的。
可以用于类似于 `analyze`/`analyse` 的单词，及日语单词（允许用户输入假名或汉字）